### PR TITLE
Fix documentation being wrapped in code example

### DIFF
--- a/src/TsJson/Decode.elm
+++ b/src/TsJson/Decode.elm
@@ -797,7 +797,7 @@ string =
     --> , tsType = "number"
     --> }
 
-    Floating point values will cause a decoding error.
+Floating point values will cause a decoding error.
 
     int
         |> runExample "1.23"


### PR DESCRIPTION
Before the fix:

![Screenshot from 2021-02-15 16-13-27](https://user-images.githubusercontent.com/3869412/107963686-c5e15580-6fa8-11eb-94cf-52ab9ea35dc2.png)
