### PR TITLE
Add tests to document behavior of `Codec.nullableField` and `Code.maybeField`

### DIFF
--- a/tests/CodecBaseTests.elm
+++ b/tests/CodecBaseTests.elm
@@ -196,6 +196,30 @@ objectTests =
                                 Err _ ->
                                     Expect.pass
                        )
+        , test "a nullableField returns the value" <|
+            \_ ->
+                """{ "f": 1 }"""
+                    |> decodeString nullableCodec
+                    |> (\r ->
+                            case r of
+                                Ok { f } ->
+                                    Expect.equal (Just 1) f
+
+                                Err _ ->
+                                    Expect.fail "Should have suceeded"
+                       )
+        , test "a nullableField hides decoder errors" <|
+            \_ ->
+                """{ "f": "string" }"""
+                    |> decodeString nullableCodec
+                    |> (\r ->
+                            case r of
+                                Ok _ ->
+                                    Expect.pass
+
+                                Err _ ->
+                                    Expect.fail "Functionality has changed"
+                       )
         , test "a nullableField produces a field with a null value on encoding Nothing" <|
             \_ ->
                 { f = Nothing }
@@ -206,6 +230,30 @@ objectTests =
                 "{}"
                     |> decodeString maybeCodec
                     |> Expect.equal (Ok { f = Nothing })
+        , test "a maybeField returns the value" <|
+            \_ ->
+                """{ "f": 1 }"""
+                    |> decodeString maybeCodec
+                    |> (\r ->
+                            case r of
+                                Ok { f } ->
+                                    Expect.equal (Just 1) f
+
+                                Err _ ->
+                                    Expect.fail "Should have succeeded"
+                       )
+        , test "a maybeField hides decoder errors" <|
+            \_ ->
+                """{ "f": "string" }"""
+                    |> decodeString maybeCodec
+                    |> (\r ->
+                            case r of
+                                Ok _ ->
+                                    Expect.pass
+
+                                Err _ ->
+                                    Expect.fail "Functionality has changed"
+                       )
         , test "a maybeField doesn't produce a field on encoding Nothing" <|
             \_ ->
                 { f = Nothing }


### PR DESCRIPTION
Thank you @dillonkearns for creating elm-ts-interop and also this nice package.

I created this PR to document a behavior that was unexpected to me:  
I had expected that `nullableField` returns an `Err` when the field exists but the decoder fails. But it returns an `Ok Nothing`.  
The generated TS type seems like it should not hide the error message `{ f : number | null }` when passing `{ f: "string"}`.

I'm not sure if this is the intended behavior or a bug, so I first wanted to add the tests and then ask for your opinion.

Would you be open to an addition of a codec with this documentation? Or changing the behavior of `nullableField`?
1. If the value is `null` the decoder will return `Nothing`.
2. If the value has the wrong type, the encoder will error out.
3. If the value is `Nothing` then the resulting object will contain the field with a `null` value.

It seems related to https://github.com/miniBill/elm-codec/pull/9#issuecomment-852930090 and it might also very well be the case that you are not interested in changing the behavior because it breaks backwards compatibility or because you want to stay close to minibills codec implementation.
